### PR TITLE
perf(stats): implement SIMD accelerated statistics + misc refactor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-#![feature(overloaded_calls, phase, slicing_syntax, tuple_indexing)]
+#![feature(if_let, macro_rules, overloaded_calls, phase, slicing_syntax, tuple_indexing)]
 
 extern crate parallel;
 #[cfg(test)]
@@ -8,12 +8,11 @@ extern crate quickcheck;
 #[phase(plugin)]
 extern crate quickcheck_macros;
 extern crate serialize;
-// FIXME Drop dependency on the `test` crate
-extern crate test;
+extern crate "test" as std_test;
 
 pub use ci::ConfidenceInterval;
 pub use sample::Sample;
-pub use stats::{mean, median, median_abs_dev, std_dev, t, var};
+pub use stats::t;
 
 pub mod kde;
 pub mod outliers;
@@ -25,7 +24,7 @@ mod resamples;
 mod sample;
 mod stats;
 #[cfg(test)]
-mod tol;
+mod test;
 
 /// The bootstrap distribution of a population parameter
 #[experimental]
@@ -84,7 +83,7 @@ impl<A: FromPrimitive + FloatMath> Distribution<A> {
     // TODO Add more methods to find the confidence interval (e.g. with bias correction)
     pub fn confidence_interval(&self, confidence_level: A) -> ConfidenceInterval<A> {
         use std::num;
-        use test::stats::Stats;
+        use std_test::stats::Stats;
 
         assert!(confidence_level > num::zero() && confidence_level < num::one());
 
@@ -102,6 +101,239 @@ impl<A: FromPrimitive + FloatMath> Distribution<A> {
 
     /// Computes the standard error of the population parameter
     pub fn standard_error(&self) -> A {
-        std_dev(self.as_slice())
+        use std_test::stats::Stats;
+
+        self.as_slice().std_dev()
+    }
+}
+
+static EMPTY_MSG: &'static str = "sample is empty";
+
+/// SIMD accelerated statistics
+// XXX T should be an associated type (?)
+pub trait Stats<T: FloatMath + FromPrimitive>: AsSlice<T> + Copy {
+    /// Returns the biggest element in the sample
+    ///
+    /// - Time: `O(length)`
+    ///
+    /// # Failure
+    ///
+    /// Fails if the sample is empty
+    fn max(self) -> T {
+        let mut elems = self.as_slice().iter();
+
+        match elems.next() {
+            Some(&elem) => elems.fold(elem, |a, &b| a.max(b)),
+            None => fail!(EMPTY_MSG),
+        }
+    }
+
+    /// Returns the arithmetic average of the sample
+    ///
+    /// - Time: `O(length)`
+    ///
+    /// # Failure
+    ///
+    /// Fails if the sample is empty
+    fn mean(self) -> T {
+        let len = self.as_slice().len();
+
+        assert!(len > 0);
+
+        self.sum() / FromPrimitive::from_uint(len).unwrap()
+    }
+
+    /// Returns the median absolute deviation
+    ///
+    /// The `median` can be optionally passed along to speed up (2X) the computation
+    ///
+    /// - Time: `O(length)`
+    /// - Memory: `O(length)`
+    ///
+    /// # Failure
+    ///
+    /// Fails if the sample is empty or if the sample contains NaN
+    fn median_abs_dev(self, median: Option<T>) -> T;
+
+    /// Returns the median absolute deviation as a percentage of the median
+    ///
+    /// - Time: `O(length)`
+    /// - Memory: `O(length)`
+    ///
+    /// # Failure
+    ///
+    /// Fails if the sample is empty or if the sample contains NaN
+    fn median_abs_dev_pct(self) -> T {
+        let hundred = FromPrimitive::from_uint(100).unwrap();
+        let median = self.percentiles().median();
+        let mad = self.median_abs_dev(Some(median));
+
+        (mad / median) * hundred
+    }
+
+    /// Returns the smallest element in the sample
+    ///
+    /// - Time: `O(length)`
+    ///
+    /// # Failure
+    ///
+    /// Fails if the sample is empty
+    fn min(self) -> T {
+        let mut elems = self.as_slice().iter();
+
+        match elems.next() {
+            Some(&elem) => elems.fold(elem, |a, &b| a.min(b)),
+            None => fail!(EMPTY_MSG),
+        }
+    }
+
+    /// Returns a "view" into the percentiles of the sample
+    ///
+    /// This "view" makes the consecutive computation of percentiles much faster
+    ///
+    /// - Time: `O(length)`
+    /// - Memory: `O(length)`
+    ///
+    /// # Failure
+    ///
+    /// Fails if the sample is empty or if the sample contains NaN
+    fn percentiles(self) -> Percentiles<T> {
+        // NB This function assumes that there are no NaNs in the sample
+        fn cmp<T: PartialOrd>(a: &T, b: &T) -> Ordering {
+            if a < b {
+                Less
+            } else if a == b {
+                Equal
+            } else {
+                Greater
+            }
+        }
+
+        let slice = self.as_slice();
+
+        assert!(slice.len() > 0 && !slice.iter().any(|x| x.is_nan()));
+
+        let mut v = slice.to_vec();
+        v[mut].sort_by(|a, b| cmp(a, b));
+        Percentiles(v)
+    }
+
+    /// Returns the standard deviation of the sample
+    ///
+    /// The `mean` can be optionally passed along to speed up (2X) the computation
+    ///
+    /// - Time: `O(length)`
+    ///
+    /// # Failure
+    ///
+    /// Fails if the sample contains less than 2 elements
+    fn std_dev(self, mean: Option<T>) -> T {
+        self.var(mean).sqrt()
+    }
+
+    /// Returns the standard deviation as a percentage of the mean
+    ///
+    /// - Time: `O(length)`
+    ///
+    /// # Failure
+    ///
+    /// Fails if the sample contains less than 2 elements
+    fn std_dev_pct(self) -> T {
+        let hundred = FromPrimitive::from_uint(100).unwrap();
+        let mean = self.mean();
+        let std_dev = self.std_dev(Some(mean));
+
+        (std_dev / mean) * hundred
+    }
+
+    /// Returns the sum of all the elements of the sample
+    ///
+    /// - Time: `O(length)`
+    fn sum(self) -> T;
+
+    /// Returns the t score between these two samples
+    fn t(self, other: Self) -> T {
+        use std::num;
+
+        let (x_bar, y_bar) = (self.mean(), other.mean());
+        let (s2_x, s2_y) = (self.var(Some(x_bar)), other.var(Some(y_bar)));
+        let n_x = num::cast::<_, T>(self.as_slice().len()).unwrap();
+        let n_y = num::cast::<_, T>(other.as_slice().len()).unwrap();
+        let num = x_bar - y_bar;
+        let den = (s2_x / n_x + s2_y / n_y).sqrt();
+
+        num / den
+    }
+
+    /// Returns the variance of the sample
+    ///
+    /// The `mean` can be optionally passed along to speed up (2X) the computation
+    ///
+    /// - Time: `O(length)`
+    ///
+    /// # Failure
+    ///
+    /// Fails if the sample contains less than 2 elements
+    fn var(self, mean: Option<T>) -> T;
+
+    #[cfg(test)]
+    fn iqr(self) -> T { self.percentiles().iqr() }
+
+    #[cfg(test)]
+    fn median(self) -> T { self.percentiles().median() }
+
+    #[cfg(test)]
+    fn quartiles(self) -> (T, T, T) { self.percentiles().quartiles() }
+}
+
+/// A "view" into the percentiles of a sample
+pub struct Percentiles<T: FloatMath + FromPrimitive>(Vec<T>);
+
+impl<T: FloatMath + FromPrimitive> Percentiles<T> {
+    /// Returns the percentile at `p`%
+    pub fn at(&self, p: T) -> T {
+        let zero = FromPrimitive::from_uint(0).unwrap();
+        let hundred = FromPrimitive::from_uint(100).unwrap();
+
+        assert!(p >= zero && p <= hundred);
+
+        let len = self.0.len() - 1;
+
+        if len == 0 {
+            self.0[0]
+        } else if p == hundred {
+            self.0[len]
+        } else {
+            let rank = (p / hundred) * FromPrimitive::from_uint(len).unwrap();
+            let integer = rank.floor();
+            let fraction = rank - integer;
+            let n = integer.to_uint().unwrap();
+            let floor = self.0[n];
+            let ceiling = self.0[n + 1];
+
+            floor + (ceiling - floor) * fraction
+        }
+    }
+
+    /// Returns the 50th percentile
+    pub fn median(&self) -> T {
+        self.at(FromPrimitive::from_uint(50).unwrap())
+    }
+
+    /// Returns the 25th, 50th and 75th percentiles
+    pub fn quartiles(&self) -> (T, T, T) {
+        (
+            self.at(FromPrimitive::from_uint(25).unwrap()),
+            self.at(FromPrimitive::from_uint(50).unwrap()),
+            self.at(FromPrimitive::from_uint(75).unwrap()),
+        )
+    }
+
+    /// Returns the interquartile range
+    pub fn iqr(&self) -> T {
+        let q1 = self.at(FromPrimitive::from_uint(25).unwrap());
+        let q3 = self.at(FromPrimitive::from_uint(75).unwrap());
+
+        q3 - q1
     }
 }

--- a/src/outliers.rs
+++ b/src/outliers.rs
@@ -1,7 +1,6 @@
 //! Classification of outliers
 
 use std::num;
-use test::stats::Stats;
 
 // TODO Add more outlier classification methods
 
@@ -64,6 +63,8 @@ impl Label {
 impl<A: FloatMath + FromPrimitive> Outliers<A> {
     /// Returns the filtered sample, and the classified outliers
     pub fn classify(sample: &[A]) -> Outliers<A> {
+        use std_test::stats::Stats;
+
         let (q1, _, q3) = sample.quartiles();
         let iqr = q3 - q1;
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,31 +1,16 @@
+use std::iter::AdditiveIterator;
 use std::num;
-use test::stats::Stats;
+use std::raw::{Repr, mod};
+use std::simd::{f32x4, f64x2};
 
-#[experimental]
-pub fn mean<A: FloatMath + FromPrimitive>(x: &[A]) -> A {
-    x.mean()
-}
+use Stats;
 
-#[experimental]
-pub fn median<A: FloatMath + FromPrimitive>(x: &[A]) -> A {
-    x.median()
-}
-
-#[experimental]
-pub fn median_abs_dev<A: FloatMath + FromPrimitive>(x: &[A]) -> A {
-    x.median_abs_dev()
-}
-
-#[experimental]
-pub fn std_dev<A: FloatMath + FromPrimitive>(x: &[A]) -> A {
-    x.std_dev()
-}
-
-/// Computes the Welch t-statistic between two samples
-#[experimental]
+/// Non accelerated version of Stats::t
 pub fn t<A: FloatMath + FromPrimitive>(x: &[A], y: &[A]) -> A {
-    let (x_bar, y_bar) = (mean(x), mean(y));
-    let (s2_x, s2_y) = (var(x), var(y));
+    use std_test::stats::Stats;
+
+    let (x_bar, y_bar) = (x.mean(), y.mean());
+    let (s2_x, s2_y) = (x.var(), y.var());
     let (n_x, n_y) = (num::cast::<_, A>(x.len()).unwrap(), num::cast::<_, A>(y.len()).unwrap());
 
     let num = x_bar - y_bar;
@@ -34,7 +19,307 @@ pub fn t<A: FloatMath + FromPrimitive>(x: &[A], y: &[A]) -> A {
     num / den
 }
 
-#[experimental]
-pub fn var<A: FloatMath + FromPrimitive>(x: &[A]) -> A {
-    x.var()
+impl<'a> Stats<f32> for &'a [f32] {
+    fn median_abs_dev(self, median: Option<f32>) -> f32 {
+        static FACTOR: f32 = 1.4826;
+
+        let median = median.unwrap_or_else(|| self.percentiles().median());
+        // NB Although this operation can be SIMD accelerated, the gain is negligible because the
+        // bottle neck is the sorting operation which is part of the computation of the median
+        let abs_devs = self.iter().map(|&x| (x - median).abs()).collect::<Vec<_>>();
+
+        abs_devs[].percentiles().median() * FACTOR
+    }
+
+    fn sum(self) -> f32 {
+        let raw::Slice { data, len } = self.repr();
+
+        if len < 8 {
+            self.iter().map(|&x| x).sum()
+        } else {
+            let data = data as *const f32x4;
+
+            let mut sum = unsafe { *data };
+            for i in range(1, (len / 4) as int) {
+                sum += unsafe { *data.offset(i) };
+            }
+
+            let tail = self.iter().rev().take(len % 4).map(|&x| x).sum();
+
+            sum.0 + sum.1 + sum.2 + sum.3 + tail
+        }
+    }
+
+    fn var(self, mean: Option<f32>) -> f32 {
+        let raw::Slice { data, len } = self.repr();
+
+        assert!(len > 1);
+
+        let mean = mean.unwrap_or_else(|| self.mean());
+        let squared_deviation = |&x: &f32| {
+            let diff = x - mean;
+            diff * diff
+        };
+
+        let sum = if len < 8 {
+            self.iter().map(squared_deviation).sum()
+        } else {
+            let data = data as *const f32x4;
+
+            let mean4 = f32x4(mean, mean, mean, mean);
+            let mut sum = f32x4(0., 0., 0., 0.);
+            for i in range(0, (len / 4) as int) {
+                let diff = unsafe { *data.offset(i) } - mean4;
+                sum += diff * diff;
+            }
+
+            let tail = self.iter().rev().take(len % 4).map(squared_deviation).sum();
+
+            sum.0 + sum.1 + sum.2 + sum.3 + tail
+        };
+
+        sum / (len - 1) as f32
+    }
+}
+
+impl<'a> Stats<f64> for &'a [f64] {
+    fn median_abs_dev(self, median: Option<f64>) -> f64 {
+        static FACTOR: f64 = 1.4826;
+
+        let median = median.unwrap_or_else(|| self.percentiles().median());
+        // NB Although this operation can be SIMD accelerated, the gain is negligible because the
+        // bottle neck is the sorting operation which is part of the computation of the median
+        let abs_devs = self.iter().map(|&x| (x - median).abs()).collect::<Vec<_>>();
+
+        abs_devs[].percentiles().median() * FACTOR
+    }
+
+    fn sum(self) -> f64 {
+        let raw::Slice { data, len } = self.repr();
+
+        if len < 4 {
+            self.iter().map(|&x| x).sum()
+        } else {
+            let data = data as *const f64x2;
+
+            let mut sum = unsafe { *data };
+            for i in range(1, (len / 2) as int) {
+                sum += unsafe { *data.offset(i) };
+            }
+
+            let tail = self.iter().rev().take(len % 2).map(|&x| x).sum();
+
+            sum.0 + sum.1 + tail
+        }
+    }
+
+    fn var(self, mean: Option<f64>) -> f64 {
+        let raw::Slice { data, len } = self.repr();
+
+        assert!(len > 1);
+
+        let mean = mean.unwrap_or_else(|| self.mean());
+        let squared_deviation = |&x: &f64| {
+            let diff = x - mean;
+            diff * diff
+        };
+
+        let sum = if len < 4 {
+            self.iter().map(squared_deviation).sum()
+        } else {
+            let data = data as *const f64x2;
+
+            let mean2 = f64x2(mean, mean);
+            let mut sum = f64x2(0., 0.);
+            for i in range(0, (len / 2) as int) {
+                let diff = unsafe { *data.offset(i) } - mean2;
+                sum += diff * diff;
+            }
+
+            let tail = self.iter().rev().take(len % 2).map(squared_deviation).sum();
+
+            sum.0 + sum.1 + tail
+        };
+
+        sum / (len - 1) as f64
+    }
+}
+
+#[cfg(test)]
+mod test {
+    macro_rules! stat {
+        ($ty:ident <- $($stat:ident),+) => {$(
+            #[quickcheck]
+            fn $stat(size: uint) -> TestResult {
+                if let Some(v) = ::test::vec::<$ty>(size) {
+                    let lhs = {
+                        use Stats;
+
+                        v[].$stat()
+                    };
+                    let rhs = {
+                        use std_test::stats::Stats;
+
+                        v[].$stat()
+                    };
+
+                    TestResult::from_bool(lhs.approx_eq(rhs))
+                } else {
+                    TestResult::discard()
+                }
+            }
+       )+}
+    }
+
+    macro_rules! stat_none {
+        ($ty:ident <- $($stat:ident),+) => {$(
+            #[quickcheck]
+            fn $stat(size: uint) -> TestResult {
+                if let Some(v) = ::test::vec::<$ty>(size) {
+                    let lhs = {
+                        use Stats;
+
+                        v[].$stat(None)
+                    };
+                    let rhs = {
+                        use std_test::stats::Stats;
+
+                        v[].$stat()
+                    };
+
+                    TestResult::from_bool(lhs.approx_eq(rhs))
+                } else {
+                    TestResult::discard()
+                }
+            }
+       )+}
+    }
+
+    macro_rules! fast_stat {
+        ($ty:ident <- $(($stat:ident, $aux_stat:ident)),+) => {$(
+            #[quickcheck]
+            fn $stat(size: uint) -> TestResult {
+                if let Some(v) = ::test::vec::<$ty>(size) {
+                    let lhs = {
+                        use Stats;
+
+                        v[].$stat(Some(v[].$aux_stat()))
+                    };
+                    let rhs = {
+                        use std_test::stats::Stats;
+
+                        v[].$stat()
+                    };
+
+                    TestResult::from_bool(lhs.approx_eq(rhs))
+                } else {
+                    TestResult::discard()
+                }
+            }
+       )+}
+    }
+
+    macro_rules! test {
+        ($($ty:ident),+) => {$(
+            mod $ty {
+                extern crate test;
+
+                use quickcheck::TestResult;
+
+                use test::ApproxEq;
+
+                stat!($ty <- iqr, max, mean, median, median_abs_dev_pct, min, quartiles,
+                        std_dev_pct, sum)
+                stat_none!($ty <- median_abs_dev, std_dev, var)
+
+                mod fast {
+                    extern crate test;
+
+                    use quickcheck::TestResult;
+
+                    use test::ApproxEq;
+
+                    fast_stat!($ty <- (median_abs_dev, median), (std_dev, mean), (var, mean))
+                }
+            }
+      )+}
+    }
+
+    test!(f32, f64)
+}
+
+#[cfg(test)]
+mod bench {
+    macro_rules! stat {
+        ($ty:ident <- $($stat:ident),+) => {$(
+            #[bench]
+            fn $stat(b: &mut Bencher) {
+                let v = ::test::vec::<$ty>(BENCH_SIZE).unwrap();
+                let s = v[];
+
+                b.iter(|| s.$stat());
+            })+
+        }
+    }
+
+    macro_rules! stat_none {
+        ($ty:ident <- $($stat:ident),+) => {$(
+            #[bench]
+            fn $stat(b: &mut Bencher) {
+                let v = ::test::vec::<$ty>(BENCH_SIZE).unwrap();
+                let s = v[];
+
+                b.iter(|| s.$stat(None));
+            })+
+        }
+    }
+
+    macro_rules! fast_stat {
+        ($ty:ident <- $(($stat:ident, $aux_stat:ident)),+) => {$(
+            #[bench]
+            fn $stat(b: &mut Bencher) {
+                let v = ::test::vec::<$ty>(BENCH_SIZE).unwrap();
+                let s = v[];
+                let aux = Some(s.$aux_stat());
+
+                b.iter(|| s.$stat(aux));
+            })+
+        }
+    }
+
+    macro_rules! bench {
+        ($($ty:ident),+) => {$(
+            mod $ty {
+                use std_test::Bencher;
+
+                use test::BENCH_SIZE;
+                use Stats;
+
+                stat!($ty <- iqr, max, mean, median, median_abs_dev_pct, min, quartiles,
+                        std_dev_pct, sum)
+                stat_none!($ty <- median_abs_dev, std_dev, var)
+
+                mod fast {
+                    use std_test::Bencher;
+
+                    use test::BENCH_SIZE;
+                    use Stats;
+
+                    fast_stat!($ty <- (median_abs_dev, median), (std_dev, mean), (var, mean))
+                }
+
+                mod std {
+                    use std_test::Bencher;
+
+                    use test::BENCH_SIZE;
+                    use std_test::stats::Stats;
+
+                    stat!($ty <- iqr, max, mean, median, median_abs_dev, median_abs_dev_pct, min,
+                            quartiles, std_dev, std_dev_pct, sum, var)
+                }
+            }
+       )+}
+    }
+
+    bench!(f32, f64)
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,41 @@
+use std::rand::{Rand, Rng, XorShiftRng, mod};
+
+pub const BENCH_SIZE: uint = 1_000_000;
+
+pub fn vec<T: Rand>(size: uint) -> Option<Vec<T>> {
+    if size > 1 {
+        let mut rng: XorShiftRng = rand::task_rng().gen();
+
+        Some(Vec::from_fn(size, |_| rng.gen()))
+    } else {
+        None
+    }
+}
+
+pub trait ApproxEq {
+    fn approx_eq(self, other: Self) -> bool;
+}
+
+macro_rules! approx {
+    ($($ty:ty),+) => {$(
+        impl ApproxEq for $ty {
+            fn approx_eq(self, other: $ty) -> bool {
+                static EPS: $ty = 1e-5;
+
+                if other == 0. {
+                    self.abs() < EPS
+                } else {
+                    (self / other - 1.) < EPS
+                }
+            }
+        }
+
+        impl ApproxEq for ($ty, $ty, $ty) {
+            fn approx_eq(self, other: ($ty, $ty, $ty)) -> bool {
+                self.0.approx_eq(other.0) && self.1.approx_eq(other.1) && self.2.approx_eq(other.2)
+            }
+        })+
+    }
+}
+
+approx!(f32, f64)

--- a/src/tol.rs
+++ b/src/tol.rs
@@ -1,9 +1,0 @@
-pub static TOLERANCE: f64 = 1e-5;
-
-pub fn is_close(x: f64, y: f64) -> bool {
-    if x == 0. || y == 0. {
-        (x - y).abs() < TOLERANCE
-    } else {
-        (x / y - 1.).abs() < TOLERANCE
-    }
-}


### PR DESCRIPTION
- Free functions like `mean`, `std_dev` has been removed, use the equivalent
  associated methods in the new `Stats` trait
- The `slope` method has been removed from `StraightLine`, instead use the
  tuple indexing notation: `line.0`
- The vector construction part of the tests has been DRYed.

[breaking-change]
