### PR TITLE
refactor(stats): improve generic programming with the `Stats` trait

### DIFF
--- a/src/kde.rs
+++ b/src/kde.rs
@@ -122,8 +122,8 @@ fn gaussian(x: f64) -> f64 {
 #[cfg(test)]
 mod test {
     use quickcheck::TestResult;
-    use std_test::stats::Stats;
 
+    use Stats;
     use kde::Kde;
     use test::{ApproxEq, mod};
 

--- a/src/outliers.rs
+++ b/src/outliers.rs
@@ -2,6 +2,8 @@
 
 use std::num;
 
+use {Simd, Stats};
+
 // TODO Add more outlier classification methods
 
 /// Classification of outliers using Tukey's fences
@@ -60,12 +62,10 @@ impl Label {
     }
 }
 
-impl<A: FloatMath + FromPrimitive> Outliers<A> {
+impl<A: Simd> Outliers<A> {
     /// Returns the filtered sample, and the classified outliers
     pub fn classify(sample: &[A]) -> Outliers<A> {
-        use std_test::stats::Stats;
-
-        let (q1, _, q3) = sample.quartiles();
+        let (q1, _, q3) = sample.percentiles().quartiles();
         let iqr = q3 - q1;
 
         let k_h: A = num::cast(3f64).unwrap();

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1,0 +1,109 @@
+use std::iter::AdditiveIterator;
+use std::raw::{Repr, mod};
+use std::simd::{f32x4, f64x2};
+
+use {Simd, Stats};
+
+impl Simd for f32 {
+    fn sum(sample: &[f32]) -> f32 {
+        let raw::Slice { data, len } = sample.repr();
+
+        if len < 8 {
+            sample.iter().map(|&x| x).sum()
+        } else {
+            let data = data as *const f32x4;
+
+            let mut sum = unsafe { *data };
+            for i in range(1, (len / 4) as int) {
+                sum += unsafe { *data.offset(i) };
+            }
+
+            let tail = sample.iter().rev().take(len % 4).map(|&x| x).sum();
+
+            sum.0 + sum.1 + sum.2 + sum.3 + tail
+        }
+    }
+
+    fn var(sample: &[f32], mean: Option<f32>) -> f32 {
+        let raw::Slice { data, len } = sample.repr();
+
+        assert!(len > 1);
+
+        let mean = mean.unwrap_or_else(|| sample.mean());
+        let squared_deviation = |&x: &f32| {
+            let diff = x - mean;
+            diff * diff
+        };
+
+        let sum = if len < 8 {
+            sample.iter().map(squared_deviation).sum()
+        } else {
+            let data = data as *const f32x4;
+
+            let mean4 = f32x4(mean, mean, mean, mean);
+            let mut sum = f32x4(0., 0., 0., 0.);
+            for i in range(0, (len / 4) as int) {
+                let diff = unsafe { *data.offset(i) } - mean4;
+                sum += diff * diff;
+            }
+
+            let tail = sample.iter().rev().take(len % 4).map(squared_deviation).sum();
+
+            sum.0 + sum.1 + sum.2 + sum.3 + tail
+        };
+
+        sum / (len - 1) as f32
+    }
+}
+
+impl Simd for f64 {
+    fn sum(sample: &[f64]) -> f64 {
+        let raw::Slice { data, len } = sample.repr();
+
+        if len < 4 {
+            sample.iter().map(|&x| x).sum()
+        } else {
+            let data = data as *const f64x2;
+
+            let mut sum = unsafe { *data };
+            for i in range(1, (len / 2) as int) {
+                sum += unsafe { *data.offset(i) };
+            }
+
+            let tail = sample.iter().rev().take(len % 2).map(|&x| x).sum();
+
+            sum.0 + sum.1 + tail
+        }
+    }
+
+    fn var(sample: &[f64], mean: Option<f64>) -> f64 {
+        let raw::Slice { data, len } = sample.repr();
+
+        assert!(len > 1);
+
+        let mean = mean.unwrap_or_else(|| sample.mean());
+        let squared_deviation = |&x: &f64| {
+            let diff = x - mean;
+            diff * diff
+        };
+
+        let sum = if len < 4 {
+            sample.iter().map(squared_deviation).sum()
+        } else {
+            let data = data as *const f64x2;
+
+            let mean2 = f64x2(mean, mean);
+            let mut sum = f64x2(0., 0.);
+            for i in range(0, (len / 2) as int) {
+                let diff = unsafe { *data.offset(i) } - mean2;
+                sum += diff * diff;
+            }
+
+            let tail = sample.iter().rev().take(len % 2).map(squared_deviation).sum();
+
+            sum.0 + sum.1 + tail
+        };
+
+        sum / (len - 1) as f64
+    }
+}

--- a/src/ttest.rs
+++ b/src/ttest.rs
@@ -1,14 +1,15 @@
 //! t-test
 
+use parallel;
 use std::{num, os, ptr};
 
-use parallel;
 use resamples::Resamples;
+use {Simd, Stats};
 
 /// A bootstrapped t distribution
 pub struct TDistribution<A>(Vec<A>);
 
-impl<A: FloatMath + FromPrimitive + Send + Sync> TDistribution<A> {
+impl<A: Simd + Send + Sync> TDistribution<A> {
     /// Computes a t distribution by bootstrapping the t-statistic between two samples
     ///
     /// * Bootstrap method: Case resampling
@@ -38,7 +39,7 @@ impl<A: FloatMath + FromPrimitive + Send + Sync> TDistribution<A> {
                     let resample = joint_resample[..n];
                     let other_resample = joint_resample[n..];
 
-                    unsafe { ptr::write(ptr, ::stats::t(resample, other_resample)) }
+                    unsafe { ptr::write(ptr, resample.t(other_resample)) }
                 }
             });
 
@@ -52,7 +53,7 @@ impl<A: FloatMath + FromPrimitive + Send + Sync> TDistribution<A> {
                 let resample = joint_resample.slice_to(n);
                 let other_resample = joint_resample.slice_from(n);
 
-                ::stats::t(resample, other_resample)
+                resample.t(other_resample)
             }).collect())
         }
     }


### PR DESCRIPTION
- `Stats` is implemented for `[T]` where `T: Simd`. Since `Simd` is implemented
  by `f32`, `f64`, the `T: Simd` bound can be used for generic programming
- the slow `::t` has been removed, use `Stats::t` instead
- T tests (`TDistribution`) are now SIMD accelerated

Closes #12
Closes #13

[breaking-change]
