### PR TITLE
fix(lib): enums are now namespaced

### DIFF
--- a/src/outliers.rs
+++ b/src/outliers.rs
@@ -2,6 +2,7 @@
 
 use std::num;
 
+use outliers::Label::{HighMild, HighSevere, LowMild, LowSevere, NotAnOutlier};
 use {Simd, Stats};
 
 // TODO Add more outlier classification methods

--- a/src/ttest.rs
+++ b/src/ttest.rs
@@ -86,16 +86,16 @@ impl<A: Float> TDistribution<A> {
 
         match tails {
             // XXX This division by two assumes that the t-distribution is symmetric
-            OneTailed => p_value / num::cast(2f64).unwrap(),
-            TwoTailed => p_value,
+            Tails::One => p_value / num::cast(2f64).unwrap(),
+            Tails::Two => p_value,
         }
     }
 }
 
 /// Number of tails to consider for the t-test
 pub enum Tails {
-    OneTailed,
-    TwoTailed,
+    One,
+    Two,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
See rust-lang/rust#18973

`Tails` variants: `OneTailed` and `TwoTailed` have been renamed to
`Tails::{One, Two}`

[breaking-change]
