### PR TITLE
remove SIMD/BLAS acceleration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,26 @@
+sudo: false
 language: rust
+
+rust: nightly
+
+before_script:
+  - |
+      pip install 'travis-cargo<0.2' --user &&
+      export PATH=$HOME/.local/bin:$PATH
+
+script:
+  - |
+      travis-cargo build &&
+      travis-cargo test &&
+      travis-cargo doc
+
+after_success:
+  - travis-cargo doc-upload
 
 env:
   global:
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: D08wHRxR0AT2yx0yXOLWKhlAxDeV7XXRCMs7yrULom3iS0BKM2qviohpYNx0Jx5NyOC97ksAz6FZ3oSSURMjW/19L9bUjZimHOIVeKFDNBn4OmUASv2LywNgFfh56z8w3znuI0bs9JOGGcH3HozW/vTENDJs3SjB7lrzszrs45g=
-
-before_install:
-  - sudo apt-get update
-
-install:
-  - sudo apt-get install libblas-dev
-
-script:
-  - cargo build --verbose
-  - cargo test --verbose
-  # run optimized tests too
-  - cargo bench test -- --test
-  - cargo doc --verbose
-  - ./check-line-length.sh
-
-after_success:
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && bash upload-docs.sh'
 
 branches:
   only: master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,21 @@
 [package]
-
 authors = ["Jorge Aparicio <japaricious@gmail.com>"]
 name = "stats"
 version = "0.0.0"
 
 [dependencies]
+cast = "0.1.0"
+floaty = "0.1.0"
 num_cpus = "0.2.10"
 rand = "0.3.13"
 thread-scoped = "1.0.1"
-cast = { git = "https://github.com/japaric/cast.rs" }
-floaty = { git = "https://github.com/japaric/float.rs" }
+
+[dev-dependencies]
+quickcheck = "0.2.25"
+quickcheck_macros = "0.2.25"
 
 [dev-dependencies.approx]
 git = "https://github.com/japaric/approx.rs"
-
-[dev-dependencies.quickcheck]
-git = "https://github.com/burntsushi/quickcheck"
-
-[dev-dependencies.quickcheck_macros]
-git = "https://github.com/burntsushi/quickcheck"
 
 [dev-dependencies.space]
 git = "https://github.com/japaric/space.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,7 @@ rand = "0.3.13"
 thread-scoped = "1.0.1"
 
 [dev-dependencies]
+approx = "0.1.0"
 itertools = "0.4.7"
 quickcheck = "0.2.25"
 quickcheck_macros = "0.2.25"
-
-[dev-dependencies.approx]
-git = "https://github.com/japaric/approx.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,8 @@ version = "0.0.0"
 num_cpus = "0.2.10"
 rand = "0.3.13"
 thread-scoped = "1.0.1"
-
-[dependencies.cast]
-git = "https://github.com/japaric/cast.rs"
-
-[dependencies.float]
-git = "https://github.com/japaric/float.rs"
+cast = { git = "https://github.com/japaric/cast.rs" }
+floaty = { git = "https://github.com/japaric/float.rs" }
 
 [dev-dependencies.approx]
 git = "https://github.com/japaric/approx.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,20 +5,15 @@ name = "stats"
 version = "0.0.0"
 
 [dependencies]
-num_cpus = "*"
-rand = "*"
-
-[dependencies.blas]
-git = "https://github.com/japaric/blas.rs"
+num_cpus = "0.2.10"
+rand = "0.3.13"
+thread-scoped = "1.0.1"
 
 [dependencies.cast]
 git = "https://github.com/japaric/cast.rs"
 
 [dependencies.float]
 git = "https://github.com/japaric/float.rs"
-
-[dependencies.simd]
-git = "https://github.com/japaric/simd.rs"
 
 [dev-dependencies.approx]
 git = "https://github.com/japaric/approx.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,9 @@ rand = "0.3.13"
 thread-scoped = "1.0.1"
 
 [dev-dependencies]
+itertools = "0.4.7"
 quickcheck = "0.2.25"
 quickcheck_macros = "0.2.25"
 
 [dev-dependencies.approx]
 git = "https://github.com/japaric/approx.rs"
-
-[dev-dependencies.space]
-git = "https://github.com/japaric/space.rs"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # stats.rs
 
-SIMD/BLAS accelerated statistics
+Statistics
 
 ## [Documentation][docs]
 

--- a/src/bivariate/bootstrap.rs
+++ b/src/bivariate/bootstrap.rs
@@ -29,12 +29,12 @@ macro_rules! test {
                         y_means.as_slice().len() == nresamples &&
                         // No uninitialized values
                         x_means.as_slice().iter().all(|&x| {
-                            (x > x_min || approx_eq!(x, x_min)) &&
-                            (x < x_max || approx_eq!(x, x_max))
+                            (x > x_min || relative_eq!(x, x_min)) &&
+                            (x < x_max || relative_eq!(x, x_max))
                         }) &&
                         y_means.as_slice().iter().all(|&y| {
-                            (y > y_min || approx_eq!(y, y_min)) &&
-                            (y < y_max || approx_eq!(y, y_max))
+                            (y > y_min || relative_eq!(y, y_min)) &&
+                            (y < y_max || relative_eq!(y, y_max))
                         })
                     )
                 } else {

--- a/src/bivariate/mod.rs
+++ b/src/bivariate/mod.rs
@@ -8,10 +8,10 @@ pub mod regression;
 use std::ptr::Unique;
 use std::{cmp, mem};
 
+use floaty::Floaty;
 use num_cpus;
 use thread_scoped as thread;
 
-use Float;
 use bivariate::resamples::Resamples;
 use tuple::{Tuple, TupledDistributions};
 use univariate::Sample;
@@ -47,7 +47,7 @@ impl<'a, X, Y> Data<'a, X, Y> {
     }
 }
 
-impl<'a, X, Y> Data<'a, X, Y> where X: Float, Y: Float {
+impl<'a, X, Y> Data<'a, X, Y> where X: Floaty, Y: Floaty {
     /// Creates a new data set from two existing slices
     pub fn new(xs: &'a [X], ys: &'a [Y]) -> Data<'a, X, Y> {
         assert!(

--- a/src/bivariate/mod.rs
+++ b/src/bivariate/mod.rs
@@ -6,9 +6,10 @@ mod resamples;
 pub mod regression;
 
 use std::ptr::Unique;
-use std::{cmp, mem, thread};
+use std::{cmp, mem};
 
 use num_cpus;
+use thread_scoped as thread;
 
 use Float;
 use bivariate::resamples::Resamples;
@@ -28,6 +29,21 @@ impl<'a, X, Y> Copy for Data<'a, X, Y> {}
 impl<'a, X, Y> Clone for Data<'a, X, Y> {
     fn clone(&self) -> Data<'a, X, Y> {
         *self
+    }
+}
+
+impl<'a, X, Y> Data<'a, X, Y> {
+    /// Returns the length of the data set
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Iterate over the data set
+    pub fn iter(&self) -> Pairs<'a, X, Y> {
+        Pairs {
+            data: *self,
+            state: 0,
+        }
     }
 }
 
@@ -108,6 +124,32 @@ impl<'a, X, Y> Data<'a, X, Y> where X: Float, Y: Float {
     pub fn y(&self) -> &'a Sample<Y> {
         unsafe {
             mem::transmute(self.1)
+        }
+    }
+}
+
+/// Iterator over `Data`
+pub struct Pairs<'a, X: 'a, Y: 'a> {
+    data: Data<'a, X, Y>,
+    state: usize,
+}
+
+impl<'a, X, Y> Iterator for Pairs<'a, X, Y> {
+    type Item = (&'a X, &'a Y);
+
+    fn next(&mut self) -> Option<(&'a X, &'a Y)> {
+        if self.state < self.data.len() {
+            let i = self.state;
+            self.state += 1;
+
+            unsafe {
+                Some((
+                    self.data.0.get_unchecked(i),
+                    self.data.1.get_unchecked(i),
+                ))
+            }
+        } else {
+            None
         }
     }
 }

--- a/src/bivariate/regression.rs
+++ b/src/bivariate/regression.rs
@@ -134,8 +134,8 @@ macro_rules! test {
                     let r_squared = sl.r_squared(data);
 
                     TestResult::from_bool(
-                        (r_squared > 0. || approx_eq!(r_squared, 0.)) &&
-                            (r_squared < 1. || approx_eq!(r_squared, 1.))
+                        (r_squared > 0. || relative_eq!(r_squared, 0.)) &&
+                            (r_squared < 1. || relative_eq!(r_squared, 1.))
                     )
                 } else {
                     TestResult::discard()

--- a/src/bivariate/regression.rs
+++ b/src/bivariate/regression.rs
@@ -1,15 +1,15 @@
 //! Regression analysis
 
-use cast::From;
+use cast::From as _0;
+use floaty::Floaty;
 
-use Float;
 use bivariate::Data;
 
 /// A straight line that passes through the origin `y = m * x`
 #[derive(Clone, Copy)]
-pub struct Slope<A>(pub A) where A: Float;
+pub struct Slope<A>(pub A) where A: Floaty;
 
-impl<A> Slope<A> where A: Float {
+impl<A> Slope<A> where A: Floaty {
     /// Fits the data to a straight line that passes through the origin using ordinary least
     /// squares
     ///
@@ -28,13 +28,13 @@ impl<A> Slope<A> where A: Float {
     ///
     /// - Time: `O(length)`
     pub fn r_squared(&self, data: Data<A, A>) -> A {
-        let _0 = A::from(0);
-        let _1 = A::from(1);
+        let _0 = A::cast(0);
+        let _1 = A::cast(1);
         let m = self.0;
         let xs = data.0;
         let ys = data.1;
 
-        let n = A::from(xs.len());
+        let n = A::cast(xs.len());
         let y_bar = ::sum(ys) / n;
 
         let mut ss_res = _0;
@@ -51,14 +51,14 @@ impl<A> Slope<A> where A: Float {
 
 /// A straight line `y = m * x + b`
 #[derive(Clone, Copy)]
-pub struct StraightLine<A> where A: Float {
+pub struct StraightLine<A> where A: Floaty {
     /// The y-intercept of the line
     pub intercept: A,
     /// The slope of the line
     pub slope: A,
 }
 
-impl<A> StraightLine<A> where A: Float {
+impl<A> StraightLine<A> where A: Floaty {
     /// Fits the data to a straight line using ordinary least squares
     ///
     /// - Time: `O(length)`
@@ -69,7 +69,7 @@ impl<A> StraightLine<A> where A: Float {
         let x2 = ::dot(xs, xs);
         let xy = ::dot(xs, ys);
 
-        let n = A::from(xs.len());
+        let n = A::cast(xs.len());
         let x2_bar = x2 / n;
         let x_bar = ::sum(xs) / n;
         let xy_bar = xy / n;
@@ -94,14 +94,14 @@ impl<A> StraightLine<A> where A: Float {
     ///
     /// - Time: `O(length)`
     pub fn r_squared(&self, data: Data<A, A>) -> A {
-        let _0 = A::from(0);
-        let _1 = A::from(1);
+        let _0 = A::cast(0);
+        let _1 = A::cast(1);
         let m = self.slope;
         let b = self.intercept;
         let xs = data.0;
         let ys = data.1;
 
-        let n = A::from(xs.len());
+        let n = A::cast(xs.len());
         let y_bar = ::sum(ys) / n;
 
         let mut ss_res = _0;

--- a/src/bivariate/resamples.rs
+++ b/src/bivariate/resamples.rs
@@ -1,17 +1,17 @@
 use rand::distributions::{IndependentSample, Range};
 use rand::{Rng, XorShiftRng};
+use floaty::Floaty;
 
-use Float;
 use bivariate::Data;
 
-pub struct Resamples<'a, X, Y> where X: 'a + Float, Y: 'a + Float {
+pub struct Resamples<'a, X, Y> where X: 'a + Floaty, Y: 'a + Floaty {
     range: Range<usize>,
     rng: XorShiftRng,
     data: (&'a [X], &'a [Y]),
     stage: Option<(Vec<X>, Vec<Y>)>,
 }
 
-impl<'a, X, Y> Resamples<'a, X, Y> where X: 'a + Float, Y: 'a + Float {
+impl<'a, X, Y> Resamples<'a, X, Y> where X: 'a + Floaty, Y: 'a + Floaty {
     pub fn new(data: Data<'a, X, Y>) -> Resamples<'a, X, Y> {
         Resamples {
             range: Range::new(0, data.0.len()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,21 @@
-//! SIMD/BLAS accelerated statistics
+//! Statistics
 
 #![cfg_attr(test, allow(trivial_casts))]  // quickcheck
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(test, plugin(quickcheck_macros))]
 #![deny(missing_docs)]
-#![deny(warnings)]
-#![feature(collections)]
-#![feature(core)]
+//#![deny(warnings)]
 #![feature(custom_attribute)]
+#![feature(fn_traits)]
 #![feature(plugin)]
-#![feature(scoped)]
 #![feature(unboxed_closures)]
 #![feature(unique)]
 
-extern crate blas;
 extern crate cast;
 extern crate float;
 extern crate num_cpus;
 extern crate rand;
-extern crate simd;
+extern crate thread_scoped;
 
 #[cfg(test)] extern crate test as stdtest;
 #[cfg(test)] extern crate approx;
@@ -50,8 +47,8 @@ use cast::From;
 
 use univariate::Sample;
 
-/// A SIMD accelerated floating point number
-pub trait Float: blas::Dot + simd::traits::Simd + float::Float + Send + Sync {}
+/// A floating point number
+pub trait Float: float::Float + Send + Sync {}
 
 impl Float for f32 {}
 impl Float for f64 {}
@@ -118,4 +115,18 @@ pub enum Tails {
     One,
     /// Two tailed test
     Two,
+}
+
+fn dot<A>(xs: &[A], ys: &[A]) -> A
+    where A: Float
+{
+    xs.iter().zip(ys).fold(A::from(0), |acc, (&x, &y)| acc + x * y)
+}
+
+fn sum<A>(xs: &[A]) -> A
+    where A: Float
+{
+    use std::ops::Add;
+
+    xs.iter().cloned().fold(A::from(0), Add::add)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,21 +17,10 @@ extern crate num_cpus;
 extern crate rand;
 extern crate thread_scoped;
 
-#[cfg(test)] extern crate approx;
+#[cfg(test)] #[macro_use] extern crate approx;
 #[cfg(test)] extern crate itertools;
 #[cfg(test)] extern crate quickcheck;
 #[cfg(test)] extern crate test as stdtest;
-
-#[cfg(test)]
-macro_rules! approx_eq {
-    ($lhs:expr, $rhs:expr) => ({
-        let ref lhs = $lhs;
-        let ref rhs = $rhs;
-
-        ::approx::eq(lhs, rhs, ::approx::Abs::tol(1e-5)) ||
-        ::approx::eq(lhs, rhs, ::approx::Rel::tol(1e-5))
-    })
-}
 
 #[cfg(test)] mod bench;
 #[cfg(test)] mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@ extern crate num_cpus;
 extern crate rand;
 extern crate thread_scoped;
 
-#[cfg(test)] extern crate test as stdtest;
 #[cfg(test)] extern crate approx;
+#[cfg(test)] extern crate itertools;
 #[cfg(test)] extern crate quickcheck;
-#[cfg(test)] extern crate space;
+#[cfg(test)] extern crate test as stdtest;
 
 #[cfg(test)]
 macro_rules! approx_eq {

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -8,13 +8,13 @@ use std::ptr;
 use Distribution;
 
 /// Any tuple: `(A, B, ..)`
-pub trait Tuple {
+pub trait Tuple: Sized {
     /// A tuple of distributions associated with this tuple
     type Distributions: TupledDistributions<Item=Self>;
 }
 
 /// A tuple of distributions: `(Distribution<A>, Distribution<B>, ..)`
-pub trait TupledDistributions {
+pub trait TupledDistributions: Sized {
     /// A tuple that can be pushed/inserted into the tupled distributions
     type Item: Tuple<Distributions=Self>;
 

--- a/src/univariate/bootstrap.rs
+++ b/src/univariate/bootstrap.rs
@@ -24,8 +24,8 @@ macro_rules! test {
                         means.as_slice().len() == nresamples &&
                         // No uninitialized values
                         means.as_slice().iter().all(|&x| {
-                            (x > min || approx_eq!(x, min)) &&
-                            (x < max || approx_eq!(x, max))
+                            (x > min || relative_eq!(x, min)) &&
+                            (x < max || relative_eq!(x, max))
                         })
                     )
                 } else {
@@ -53,12 +53,12 @@ macro_rules! test {
                         medians.as_slice().len() == nresamples &&
                         // No uninitialized values
                         means.as_slice().iter().all(|&x| {
-                            (x > min || approx_eq!(x, min)) &&
-                            (x < max || approx_eq!(x, max))
+                            (x > min || relative_eq!(x, min)) &&
+                            (x < max || relative_eq!(x, max))
                         }) &&
                         medians.as_slice().iter().all(|&x| {
-                            (x > min || approx_eq!(x, min)) &&
-                            (x < max || approx_eq!(x, max))
+                            (x > min || relative_eq!(x, min)) &&
+                            (x < max || relative_eq!(x, max))
                         })
                     )
                 } else {
@@ -92,8 +92,8 @@ macro_rules! test {
                         distribution.as_slice().len() == nresamples &&
                         // No uninitialized values
                         distribution.as_slice().iter().all(|&x| {
-                            (x > min || approx_eq!(x, min)) &&
-                            (x < max || approx_eq!(x, max))
+                            (x > min || relative_eq!(x, min)) &&
+                            (x < max || relative_eq!(x, max))
                         })
                     )
                 } else {
@@ -127,8 +127,8 @@ macro_rules! test {
                         distribution.as_slice().len() == nresamples &&
                         // No uninitialized values
                         distribution.as_slice().iter().all(|&x| {
-                            (x > min || approx_eq!(x, min)) &&
-                            (x < max || approx_eq!(x, max))
+                            (x > min || relative_eq!(x, min)) &&
+                            (x < max || relative_eq!(x, max))
                         })
                     )
                 } else {

--- a/src/univariate/kde/kernel.rs
+++ b/src/univariate/kde/kernel.rs
@@ -15,9 +15,9 @@ pub struct Gaussian;
 
 impl<A> Fn<(A,)> for Gaussian where A: Float {
     extern "rust-call" fn call(&self, (x,): (A,)) -> A {
-        use std::f32::consts::PI_2;
+        use std::f32::consts::PI;
 
-        (x.powi(2).exp() * A::from(PI_2)).sqrt().recip()
+        (x.powi(2).exp() * A::from(2. * PI)).sqrt().recip()
     }
 }
 

--- a/src/univariate/kde/kernel.rs
+++ b/src/univariate/kde/kernel.rs
@@ -44,7 +44,7 @@ macro_rules! test {
 
                 #[quickcheck]
                 fn symmetric(x: $ty) -> bool {
-                    approx_eq!(Gaussian(-x), Gaussian(x))
+                    relative_eq!(Gaussian(-x), Gaussian(x))
                 }
 
                 // Any [a b] integral should be in the range [0 1]
@@ -69,7 +69,7 @@ macro_rules! test {
                         }
 
                         TestResult::from_bool(
-                            (acc > 0. || approx_eq!(acc, 0.)) && (acc < 1. || approx_eq!(acc, 1.)))
+                            (acc > 0. || relative_eq!(acc, 0.)) && (acc < 1. || relative_eq!(acc, 1.)))
                     }
                 }
             }

--- a/src/univariate/kde/kernel.rs
+++ b/src/univariate/kde/kernel.rs
@@ -1,33 +1,32 @@
 //! Kernels
 
-use cast::From;
-
-use Float;
+use cast::From as _0;
+use floaty::Floaty;
 
 /// Kernel function
-pub trait Kernel<A>: Copy + Fn(A) -> A + Sync where A: Float {}
+pub trait Kernel<A>: Copy + Fn(A) -> A + Sync where A: Floaty {}
 
-impl<A, K> Kernel<A> for K where K: Copy + Fn(A) -> A + Sync, A: Float {}
+impl<A, K> Kernel<A> for K where K: Copy + Fn(A) -> A + Sync, A: Floaty {}
 
 /// Gaussian kernel
 #[derive(Clone, Copy)]
 pub struct Gaussian;
 
-impl<A> Fn<(A,)> for Gaussian where A: Float {
+impl<A> Fn<(A,)> for Gaussian where A: Floaty {
     extern "rust-call" fn call(&self, (x,): (A,)) -> A {
         use std::f32::consts::PI;
 
-        (x.powi(2).exp() * A::from(2. * PI)).sqrt().recip()
+        (x.powi(2).exp() * A::cast(2. * PI)).sqrt().recip()
     }
 }
 
-impl<A> FnMut<(A,)> for Gaussian where A: Float {
+impl<A> FnMut<(A,)> for Gaussian where A: Floaty {
     extern "rust-call" fn call_mut(&mut self, args: (A,)) -> A {
         self.call(args)
     }
 }
 
-impl<A> FnOnce<(A,)> for Gaussian where A: Float {
+impl<A> FnOnce<(A,)> for Gaussian where A: Floaty {
     type Output = A;
 
     extern "rust-call" fn call_once(self, args: (A,)) -> A {

--- a/src/univariate/kde/mod.rs
+++ b/src/univariate/kde/mod.rs
@@ -132,10 +132,8 @@ macro_rules! test {
             use univariate::kde::kernel::Gaussian;
             use univariate::kde::{Bandwidth, Kde};
 
-            // FIXME flaky test for `f32`
             // The [-inf inf] integral of the estimated PDF should be one
             #[quickcheck]
-            #[ignore]
             fn integral(size: usize, start: usize) -> TestResult {
                 const DX: $ty = 1e-3;
 
@@ -161,7 +159,7 @@ macro_rules! test {
                         acc += DX * y / 2.;
                     }
 
-                    TestResult::from_bool(approx_eq!(acc, 1.))
+                    TestResult::from_bool(relative_eq!(acc, 1., epsilon = 2e-5))
                 } else {
                     TestResult::discard()
                 }

--- a/src/univariate/kde/mod.rs
+++ b/src/univariate/kde/mod.rs
@@ -204,7 +204,7 @@ macro_rules! bench {
             fn map(b: &mut Bencher) {
                 let data = ::test::vec(SAMPLE_SIZE, 0).unwrap();
                 let kde = Kde::new(Sample::new(&data), Gaussian, Bandwidth::Silverman);
-                let xs: Vec<_> = ::space::linspace::<$ty>(0., 1., KDE_POINTS).collect();
+                let xs: Vec<_> = ::itertools::linspace::<$ty>(0., 1., KDE_POINTS).collect();
 
                 b.iter(|| {
                     kde.map(&xs)

--- a/src/univariate/kde/mod.rs
+++ b/src/univariate/kde/mod.rs
@@ -4,23 +4,23 @@ pub mod kernel;
 
 use std::ptr;
 
-use cast::From;
+use cast::From as _0;
+use floaty::Floaty;
 use num_cpus;
 use thread_scoped as thread;
 
-use Float;
 use univariate::Sample;
 
 use self::kernel::Kernel;
 
 /// Univariate kernel density estimator
-pub struct Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
+pub struct Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
     bandwidth: A,
     kernel: K,
     sample: &'a Sample<A>,
 }
 
-impl<'a, A, K> Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
+impl<'a, A, K> Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
     /// Creates a new kernel density estimator from the `sample`, using a kernel `k` and estimating
     /// the bandwidth using the method `bw`
     pub fn new(sample: &'a Sample<A>, k: K, bw: Bandwidth<A>) -> Kde<'a, A, K> {
@@ -71,13 +71,13 @@ impl<'a, A, K> Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
     }
 }
 
-impl<'a, A, K> Fn<(A,)> for Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
+impl<'a, A, K> Fn<(A,)> for Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
     /// Estimates the probability density of `x`
     extern "rust-call" fn call(&self, (x,): (A,)) -> A {
-        let _0 = A::from(0);
+        let _0 = A::cast(0);
         let slice = self.sample.as_slice();
         let h = self.bandwidth;
-        let n = A::from(slice.len());
+        let n = A::cast(slice.len());
 
         let sum = slice.iter().fold(_0, |acc, &x_i| acc + (self.kernel)((x - x_i) / h));
 
@@ -85,13 +85,13 @@ impl<'a, A, K> Fn<(A,)> for Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
     }
 }
 
-impl<'a, A, K> FnMut<(A,)> for Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
+impl<'a, A, K> FnMut<(A,)> for Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
     extern "rust-call" fn call_mut(&mut self, args: (A,)) -> A {
         self.call(args)
     }
 }
 
-impl<'a, A, K> FnOnce<(A,)> for Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
+impl<'a, A, K> FnOnce<(A,)> for Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
     type Output = A;
 
     extern "rust-call" fn call_once(self, args: (A,)) -> A {
@@ -100,20 +100,20 @@ impl<'a, A, K> FnOnce<(A,)> for Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> 
 }
 
 /// Method to estimate the bandwidth
-pub enum Bandwidth<A> where A: Float {
+pub enum Bandwidth<A> where A: Floaty {
     /// Use this value as the bandwidth
     Manual(A),
     /// Use Silverman's rule of thumb to estimate the bandwidth from the sample
     Silverman,
 }
 
-impl<A> Bandwidth<A> where A: Float {
+impl<A> Bandwidth<A> where A: Floaty {
     fn estimate(self, sample: &Sample<A>) -> A {
         match self {
             Bandwidth::Silverman => {
-                let factor = A::from(4. / 3.);
-                let exponent = A::from(1. / 5.);
-                let n = A::from(sample.as_slice().len());
+                let factor = A::cast(4. / 3.);
+                let exponent = A::cast(1. / 5.);
+                let n = A::cast(sample.as_slice().len());
                 let sigma = sample.std_dev(None);
 
                 sigma * (factor / n).powf(exponent)

--- a/src/univariate/mixed.rs
+++ b/src/univariate/mixed.rs
@@ -1,9 +1,10 @@
 //! Mixed bootstrap
 
 use std::ptr::Unique;
-use std::{cmp, mem, thread};
+use std::{cmp, mem};
 
 use num_cpus;
+use thread_scoped as thread;
 
 use Float;
 use tuple::{Tuple, TupledDistributions};
@@ -26,8 +27,8 @@ pub fn bootstrap<A, T, S>(
     let n_a = a.as_slice().len();
     let n_b = b.as_slice().len();
     let mut c = Vec::with_capacity(n_a + n_b);
-    c.push_all(a.as_slice());
-    c.push_all(b.as_slice());
+    c.extend_from_slice(a.as_slice());
+    c.extend_from_slice(b.as_slice());
 
     unsafe {
         //let c: &Sample<A> = mem::transmute(c.as_slice());

--- a/src/univariate/mixed.rs
+++ b/src/univariate/mixed.rs
@@ -3,10 +3,10 @@
 use std::ptr::Unique;
 use std::{cmp, mem};
 
+use floaty::Floaty;
 use num_cpus;
 use thread_scoped as thread;
 
-use Float;
 use tuple::{Tuple, TupledDistributions};
 use univariate::Sample;
 use univariate::resamples::Resamples;
@@ -18,7 +18,7 @@ pub fn bootstrap<A, T, S>(
     nresamples: usize,
     statistic: S,
 ) -> T::Distributions where
-    A: Float,
+    A: Floaty,
     S: Fn(&Sample<A>, &Sample<A>) -> T + Sync,
     T: Tuple,
     T::Distributions: Send,

--- a/src/univariate/mod.rs
+++ b/src/univariate/mod.rs
@@ -12,10 +12,10 @@ pub mod outliers;
 use std::ptr::Unique;
 use std::cmp;
 
+use floaty::Floaty;
 use num_cpus;
 use thread_scoped as thread;
 
-use Float;
 use tuple::{Tuple, TupledDistributions};
 
 use self::resamples::Resamples;
@@ -34,8 +34,8 @@ pub fn bootstrap<A, B, T, S>(
     nresamples: usize,
     statistic: S,
 ) -> T::Distributions where
-    A: Float,
-    B: Float,
+    A: Floaty,
+    B: Floaty,
     S: Fn(&Sample<A>, &Sample<B>) -> T,
     S: Sync,
     T: Tuple,

--- a/src/univariate/mod.rs
+++ b/src/univariate/mod.rs
@@ -10,9 +10,10 @@ pub mod mixed;
 pub mod outliers;
 
 use std::ptr::Unique;
-use std::{cmp, thread};
+use std::cmp;
 
 use num_cpus;
+use thread_scoped as thread;
 
 use Float;
 use tuple::{Tuple, TupledDistributions};

--- a/src/univariate/percentiles.rs
+++ b/src/univariate/percentiles.rs
@@ -1,29 +1,28 @@
-use cast::From;
-
-use Float;
+use cast::{self, usize, From as _0};
+use floaty::Floaty;
 
 /// A "view" into the percentiles of a sample
-pub struct Percentiles<A>(Box<[A]>) where A: Float;
+pub struct Percentiles<A>(Box<[A]>) where A: Floaty;
 
 // TODO(rust-lang/rfcs#735) move this `impl` into a private percentiles module
-impl<A> Percentiles<A> where A: Float, usize: From<A, Output=Option<usize>> {
+impl<A> Percentiles<A> where A: Floaty, usize: cast::From<A, Output=Result<usize, cast::Error>> {
     /// Returns the percentile at `p`%
     ///
     /// Safety:
     ///
     /// - Make sure that `p` is in the range `[0, 100]`
     unsafe fn at_unchecked(&self, p: A) -> A {
-        let _0 = A::from(0);
-        let _100 = A::from(100);
+        let _0 = A::cast(0);
+        let _100 = A::cast(100);
         let len = self.0.len() - 1;
 
         if p == _100 {
             self.0[len]
         } else {
-            let rank = (p / _100) * A::from(len);
+            let rank = (p / _100) * A::cast(len);
             let integer = rank.floor();
             let fraction = rank - integer;
-            let n = usize::from(integer).unwrap();
+            let n = usize(integer).unwrap();
             let &floor = self.0.get_unchecked(n);
             let &ceiling = self.0.get_unchecked(n + 1);
 
@@ -37,8 +36,8 @@ impl<A> Percentiles<A> where A: Float, usize: From<A, Output=Option<usize>> {
     ///
     /// Panics if `p` is outside the closed `[0, 100]` range
     pub fn at(&self, p: A) -> A {
-        let _0 = A::from(0);
-        let _100 = A::from(100);
+        let _0 = A::cast(0);
+        let _100 = A::cast(100);
 
         assert!(p >= _0 && p <= _100);
 
@@ -50,8 +49,8 @@ impl<A> Percentiles<A> where A: Float, usize: From<A, Output=Option<usize>> {
     /// Returns the interquartile range
     pub fn iqr(&self) -> A {
         unsafe {
-            let q1 = self.at_unchecked(A::from(25));
-            let q3 = self.at_unchecked(A::from(75));
+            let q1 = self.at_unchecked(A::cast(25));
+            let q3 = self.at_unchecked(A::cast(75));
 
             q3 - q1
         }
@@ -60,7 +59,7 @@ impl<A> Percentiles<A> where A: Float, usize: From<A, Output=Option<usize>> {
     /// Returns the 50th percentile
     pub fn median(&self) -> A {
         unsafe {
-            self.at_unchecked(A::from(50))
+            self.at_unchecked(A::cast(50))
         }
     }
 
@@ -68,9 +67,9 @@ impl<A> Percentiles<A> where A: Float, usize: From<A, Output=Option<usize>> {
     pub fn quartiles(&self) -> (A, A, A) {
         unsafe {
             (
-                self.at_unchecked(A::from(25)),
-                self.at_unchecked(A::from(50)),
-                self.at_unchecked(A::from(75)),
+                self.at_unchecked(A::cast(25)),
+                self.at_unchecked(A::cast(50)),
+                self.at_unchecked(A::cast(75)),
             )
         }
     }

--- a/src/univariate/resamples.rs
+++ b/src/univariate/resamples.rs
@@ -1,19 +1,19 @@
 use std::mem;
 
+use floaty::Floaty;
 use rand::distributions::{IndependentSample, Range};
 use rand::{Rng, XorShiftRng};
 
-use Float;
 use univariate::Sample;
 
-pub struct Resamples<'a, A> where A: 'a + Float {
+pub struct Resamples<'a, A> where A: 'a + Floaty {
     range: Range<usize>,
     rng: XorShiftRng,
     sample: &'a [A],
     stage: Option<Vec<A>>,
 }
 
-impl <'a, A> Resamples<'a, A> where A: 'a + Float {
+impl <'a, A> Resamples<'a, A> where A: 'a + Floaty {
     pub fn new(sample: &'a Sample<A>) -> Resamples<'a, A> {
         let slice = sample.as_slice();
 

--- a/src/univariate/sample.rs
+++ b/src/univariate/sample.rs
@@ -1,11 +1,11 @@
 use std::ptr::Unique;
 use std::{cmp, mem};
 
-use cast::From;
+use cast::{self, From as _0};
+use floaty::Floaty;
 use num_cpus;
 use thread_scoped as thread;
 
-use Float;
 use tuple::{Tuple, TupledDistributions};
 use univariate::Percentiles;
 use univariate::resamples::Resamples;
@@ -34,7 +34,7 @@ impl<A> Sample<A> {
 }
 
 // TODO(rust-lang/rfcs#735) move this `impl` into a private percentiles module
-impl<A> Sample<A> where A: Float {
+impl<A> Sample<A> where A: Floaty {
     /// Creates a new sample from an existing slice
     ///
     /// # Panics
@@ -70,7 +70,7 @@ impl<A> Sample<A> where A: Float {
     pub fn mean(&self) -> A {
         let n = self.as_slice().len();
 
-        self.sum() / A::from(n)
+        self.sum() / A::cast(n)
     }
 
     /// Returns the median absolute deviation
@@ -80,7 +80,7 @@ impl<A> Sample<A> where A: Float {
     /// - Time: `O(length)`
     /// - Memory: `O(length)`
     pub fn median_abs_dev(&self, median: Option<A>) -> A where
-        usize: From<A, Output=Option<usize>>,
+        usize: cast::From<A, Output=Result<usize, cast::Error>>,
     {
         let median = median.unwrap_or_else(|| self.percentiles().median());
 
@@ -92,7 +92,7 @@ impl<A> Sample<A> where A: Float {
             mem::transmute(&*abs_devs)
         };
 
-        abs_devs.percentiles().median() * A::from(1.4826)
+        abs_devs.percentiles().median() * A::cast(1.4826)
     }
 
     /// Returns the median absolute deviation as a percentage of the median
@@ -100,9 +100,9 @@ impl<A> Sample<A> where A: Float {
     /// - Time: `O(length)`
     /// - Memory: `O(length)`
     pub fn median_abs_dev_pct(&self) -> A where
-        usize: From<A, Output=Option<usize>>,
+        usize: cast::From<A, Output=Result<usize, cast::Error>>,
     {
-        let _100 = A::from(100);
+        let _100 = A::cast(100);
         let median = self.percentiles().median();
         let mad = self.median_abs_dev(Some(median));
 
@@ -129,7 +129,7 @@ impl<A> Sample<A> where A: Float {
     /// - Time: `O(N log N) where N = length`
     /// - Memory: `O(length)`
     pub fn percentiles(&self) -> Percentiles<A> where
-        usize: From<A, Output=Option<usize>>,
+        usize: cast::From<A, Output=Result<usize, cast::Error>>,
     {
         use std::cmp::Ordering;
 
@@ -166,7 +166,7 @@ impl<A> Sample<A> where A: Float {
     ///
     /// - Time: `O(length)`
     pub fn std_dev_pct(&self) -> A {
-        let _100 = A::from(100);
+        let _100 = A::cast(100);
         let mean = self.mean();
         let std_dev = self.std_dev(Some(mean));
 
@@ -186,8 +186,8 @@ impl<A> Sample<A> where A: Float {
     pub fn t(&self, other: &Sample<A>) -> A {
         let (x_bar, y_bar) = (self.mean(), other.mean());
         let (s2_x, s2_y) = (self.var(Some(x_bar)), other.var(Some(y_bar)));
-        let n_x = A::from(self.as_slice().len());
-        let n_y = A::from(other.as_slice().len());
+        let n_x = A::cast(self.as_slice().len());
+        let n_y = A::cast(other.as_slice().len());
         let num = x_bar - y_bar;
         let den = (s2_x / n_x + s2_y / n_y).sqrt();
 
@@ -205,9 +205,9 @@ impl<A> Sample<A> where A: Float {
         let mean = mean.unwrap_or_else(|| self.mean());
         let slice = self.as_slice();
 
-        let sum = slice.iter().map(|&x| (x - mean).powi(2)).fold(A::from(0), Add::add);
+        let sum = slice.iter().map(|&x| (x - mean).powi(2)).fold(A::cast(0), Add::add);
 
-        sum / A::from(slice.len() - 1)
+        sum / A::cast(slice.len() - 1)
     }
 
     // TODO Remove the `T` parameter in favor of `S::Output`
@@ -269,14 +269,14 @@ impl<A> Sample<A> where A: Float {
 
     #[cfg(test)]
     pub fn iqr(&self) -> A where
-        usize: From<A, Output=Option<usize>>,
+        usize: cast::From<A, Output=Result<usize, cast::Error>>,
     {
         self.percentiles().iqr()
     }
 
     #[cfg(test)]
     pub fn median(&self) -> A where
-        usize: From<A, Output=Option<usize>>,
+        usize: cast::From<A, Output=Result<usize, cast::Error>>,
     {
         self.percentiles().median()
     }

--- a/src/univariate/sample.rs
+++ b/src/univariate/sample.rs
@@ -305,7 +305,7 @@ mod test {
                         let lhs = ::univariate::Sample::new(slice).$stat();
                         let rhs = slice.$stat();
 
-                        TestResult::from_bool(approx_eq!(lhs, rhs))
+                        TestResult::from_bool(relative_eq!(lhs, rhs, max_relative = 1e-5))
                     } else {
                         TestResult::discard()
                     }
@@ -324,7 +324,7 @@ mod test {
                         let lhs = ::univariate::Sample::new(slice).$stat(None);
                         let rhs = slice.$stat();
 
-                        TestResult::from_bool(approx_eq!(lhs, rhs))
+                        TestResult::from_bool(relative_eq!(lhs, rhs, max_relative = 1e-5))
                     } else {
                         TestResult::discard()
                     }
@@ -347,7 +347,7 @@ mod test {
                         };
                         let rhs = slice.$stat();
 
-                        TestResult::from_bool(approx_eq!(lhs, rhs))
+                        TestResult::from_bool(relative_eq!(lhs, rhs, max_relative = 1e-5))
                     } else {
                         TestResult::discard()
                     }


### PR DESCRIPTION
We're stripping unnecessary features to get criterion-0.1 out of the door. Both
SIMD and BLAS can come back in the future as they don't change criterion's
public API.

---

Although all test pass, I'll merge this PR after testing it with an updated criterion, because the plots make it easier to spot bugs.

cc @faern