### PR TITLE
Add clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,11 @@ before_script:
 
 install:
   - sh ci/install.sh
+  - export PATH=$HOME/cargo-clippy/target/release:$PATH
 
 script:
   - cargo build --target $TARGET
+  - cargo clippy --target $TARGET -- --cfg clippy
   - cargo test --target $TARGET
   - cargo doc --target $TARGET
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -2,6 +2,13 @@
 
 set -ex
 
+oldpath=$(pwd)
+cd $HOME
+git clone https://github.com/arcnmx/cargo-clippy
+cd $HOME/cargo-clippy
+cargo build --release
+cd $oldpath
+
 case $TARGET in
   # Install standard libraries needed for cross compilation
   arm-unknown-linux-gnueabihf | \

--- a/src/bivariate/mod.rs
+++ b/src/bivariate/mod.rs
@@ -26,6 +26,7 @@ pub struct Data<'a, X, Y>(&'a [X], &'a [Y]) where X: 'a, Y: 'a;
 
 impl<'a, X, Y> Copy for Data<'a, X, Y> {}
 
+#[cfg_attr(clippy, allow(expl_impl_clone_on_copy))]
 impl<'a, X, Y> Clone for Data<'a, X, Y> {
     fn clone(&self) -> Data<'a, X, Y> {
         *self
@@ -36,6 +37,11 @@ impl<'a, X, Y> Data<'a, X, Y> {
     /// Returns the length of the data set
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    /// Checks whether the data set is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Iterate over the data set
@@ -82,7 +88,7 @@ impl<'a, X, Y> Data<'a, X, Y> where X: Floaty, Y: Floaty {
                 let mut distributions: T::Distributions =
                     TupledDistributions::uninitialized(nresamples);
 
-                (0..ncpus).map(|i| {
+                let _ = (0..ncpus).map(|i| {
                     // NB Can't implement `chunks_mut` for the tupled distributions without HKT,
                     // for now I'll make do with aliasing and careful non-overlapping indexing
                     let mut ptr = Unique::new(&mut distributions);

--- a/src/bivariate/resamples.rs
+++ b/src/bivariate/resamples.rs
@@ -11,6 +11,7 @@ pub struct Resamples<'a, X, Y> where X: 'a + Floaty, Y: 'a + Floaty {
     stage: Option<(Vec<X>, Vec<Y>)>,
 }
 
+#[cfg_attr(clippy, allow(should_implement_trait))]
 impl<'a, X, Y> Resamples<'a, X, Y> where X: 'a + Floaty, Y: 'a + Floaty {
     pub fn new(data: Data<'a, X, Y>) -> Resamples<'a, X, Y> {
         Resamples {
@@ -23,7 +24,7 @@ impl<'a, X, Y> Resamples<'a, X, Y> where X: 'a + Floaty, Y: 'a + Floaty {
 
     pub fn next(&mut self) -> Data<X, Y> {
         let n = self.data.0.len();
-        let ref mut rng = self.rng;
+        let rng = &mut self.rng;
 
         match self.stage {
             None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(plugin)]
 #![feature(unboxed_closures)]
 #![feature(unique)]
+#![cfg_attr(clippy, allow(used_underscore_binding))]
 
 extern crate cast;
 extern crate floaty;

--- a/src/univariate/kde/mod.rs
+++ b/src/univariate/kde/mod.rs
@@ -52,7 +52,7 @@ impl<'a, A, K> Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
                 ys.set_len(n);
 
                 {
-                    ys.chunks_mut(granularity).enumerate().map(|(i, ys)| {
+                    let _ = ys.chunks_mut(granularity).enumerate().map(|(i, ys)| {
                         let offset = i * granularity;
 
                         thread::scoped(move || {

--- a/src/univariate/mixed.rs
+++ b/src/univariate/mixed.rs
@@ -37,11 +37,11 @@ pub fn bootstrap<A, T, S>(
         // TODO need some sensible threshold to trigger the multi-threaded path
         if ncpus > 10 && nresamples > n_a {
             let granularity = nresamples / ncpus + 1;
-            let ref statistic = statistic;
+            let statistic = &statistic;
             let mut distributions: T::Distributions =
                 TupledDistributions::uninitialized(nresamples);
 
-            (0..ncpus).map(|i| {
+            let _ = (0..ncpus).map(|i| {
                 // NB Can't implement `chunks_mut` for the tupled distributions without HKT,
                 // for now I'll make do with aliasing and careful non-overlapping indexing
                 let mut ptr = Unique::new(&mut distributions);

--- a/src/univariate/percentiles.rs
+++ b/src/univariate/percentiles.rs
@@ -12,7 +12,6 @@ impl<A> Percentiles<A> where A: Floaty, usize: cast::From<A, Output=Result<usize
     ///
     /// - Make sure that `p` is in the range `[0, 100]`
     unsafe fn at_unchecked(&self, p: A) -> A {
-        let _0 = A::cast(0);
         let _100 = A::cast(100);
         let len = self.0.len() - 1;
 

--- a/src/univariate/resamples.rs
+++ b/src/univariate/resamples.rs
@@ -13,6 +13,7 @@ pub struct Resamples<'a, A> where A: 'a + Floaty {
     stage: Option<Vec<A>>,
 }
 
+#[cfg_attr(clippy, allow(should_implement_trait))]
 impl <'a, A> Resamples<'a, A> where A: 'a + Floaty {
     pub fn new(sample: &'a Sample<A>) -> Resamples<'a, A> {
         let slice = sample.as_slice();
@@ -27,7 +28,7 @@ impl <'a, A> Resamples<'a, A> where A: 'a + Floaty {
 
     pub fn next(&mut self) -> &Sample<A> {
         let n = self.sample.len();
-        let ref mut rng = self.rng;
+        let rng = &mut self.rng;
 
         match self.stage {
             None => {

--- a/src/univariate/sample.rs
+++ b/src/univariate/sample.rs
@@ -236,7 +236,7 @@ impl<A> Sample<A> where A: Floaty {
                 let mut distributions: T::Distributions =
                     TupledDistributions::uninitialized(nresamples);
 
-                (0..ncpus).map(|i| {
+                let _ = (0..ncpus).map(|i| {
                     // NB Can't implement `chunks_mut` for the tupled distributions without HKT,
                     // for now I'll make do with aliasing and careful non-overlapping indexing
                     let mut ptr = Unique::new(&mut distributions);


### PR DESCRIPTION
- Add `clippy` to the list of dependencies.
- Add a `lint` feature that enables `clippy` for now.
- Appease `clippy`'s lints.