### PR TITLE
Fix build breakage on latest nightly

### DIFF
--- a/src/bivariate/mod.rs
+++ b/src/bivariate/mod.rs
@@ -96,7 +96,7 @@ impl<'a, X, Y> Data<'a, X, Y> where X: Floaty, Y: Floaty {
                     let offset = i * granularity;
 
                     thread::scoped(move || {
-                        let distributions: &mut T::Distributions = ptr.get_mut();
+                        let distributions: &mut T::Distributions = ptr.as_mut();
 
                         for i in offset..cmp::min(offset + granularity, nresamples) {
                             distributions.set_unchecked(i, statistic(resamples.next()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(test, plugin(quickcheck_macros))]
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![feature(custom_attribute)]
 #![feature(fn_traits)]
 #![feature(plugin)]

--- a/src/univariate/mixed.rs
+++ b/src/univariate/mixed.rs
@@ -48,7 +48,7 @@ pub fn bootstrap<A, T, S>(
                 let offset = i * granularity;
 
                 thread::scoped(move || {
-                    let distributions: &mut T::Distributions = ptr.get_mut();
+                    let distributions: &mut T::Distributions = ptr.as_mut();
                     let end = cmp::min(offset + granularity, nresamples);
                     let mut resamples = Resamples::new(c);
 

--- a/src/univariate/sample.rs
+++ b/src/univariate/sample.rs
@@ -244,7 +244,7 @@ impl<A> Sample<A> where A: Floaty {
                     let offset = i * granularity;
 
                     thread::scoped(move || {
-                        let distributions: &mut T::Distributions = ptr.get_mut();
+                        let distributions: &mut T::Distributions = ptr.as_mut();
 
                         for i in offset..cmp::min(offset + granularity, nresamples) {
                             distributions.set_unchecked(i, statistic(resamples.next()))


### PR DESCRIPTION
I fixed some build breakages. In general stats uses to many unstable features needlessly. Also, stats uses the antipattern of deny(warnings) which makes it annoying for third-party consumers to build the code.

In the future I might like to reduce criterion's dependency on unstable features or gate them behind flags but for now I just fixed the immediate breakage.